### PR TITLE
Added Tomiwa Ademidun (@tomiwa1a) to black speaker in tech and proposal for adding personal website links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ If anyone is reported as malicious or making others feel uncomfortable, they may
 
 ### Canada
 
+#### Tomiwa Ademidun
+
+- [@tomiwa1a](http://twitter.com/tomiwa1a)
+- Topics - Anuglar, React, Python, Django, Progressive Web Apps, Devops, Entrepreneurship
+- Location - Toronto, Canada
+
 #### Hassan Djirdeh
 
 - [@djirdehh](http://twitter.com/djirdehh)


### PR DESCRIPTION
PR to add myself (@tomiwa1a) to black speaker in tech because I am a black speaker in tech 🙂

Also, can I propose that we add another line for users to add an optional link to their own personal portfolio.

Such as their personal website, blog, etc.

I think people may prefer to have the option to drive interested people to their own websites rather than 3rd party platform like Twitter.

Example:
```markdown
#### Tomiwa Ademidun

- [@tomiwa1a](http://twitter.com/tomiwa1a)
- https://tomiwa.ca
- Topics - Anuglar, React, Python, Django, Progressive Web Apps, Devops, Entrepreneurship
- Location - Toronto, Canada


```